### PR TITLE
feat: Configuração inicial da API com DRF e Swagger

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = [
     'rest_framework',
     'drf_spectacular',
     'django_filters',
+    'drf_yasg',
 
     'users',
     'products',

--- a/app/urls.py
+++ b/app/urls.py
@@ -1,22 +1,18 @@
-"""
-URL configuration for app project.
+# app/urls.py
 
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/5.2/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  path('', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
-Including another URLconf
-    1. Import the include() function: from django.urls import include, path
-    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
-"""
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include # Importe 'include' aqui!
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView, SpectacularRedocView # Inclua Redoc se quiser
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+
+    # URLs para o DRF Spectacular (Documentação OpenAPI/Swagger)
+    path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
+    path('api/schema/swagger-ui/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
+    path('api/schema/redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'), # Opcional: Redoc
+
+    # Inclua as URLs do seu app 'products' aqui
+    # É crucial que as URLs dos seus apps estejam incluídas!
+    path('api/', include('products.urls')), # Isso vai incluir '/api/categories/' e '/api/products/'
 ]

--- a/products/serializers.py
+++ b/products/serializers.py
@@ -1,0 +1,22 @@
+# products/serializers.py
+
+from rest_framework import serializers
+from .models import Category, Product
+
+class CategorySerializer(serializers.ModelSerializer):
+    '''
+    Serializador para o modelo Category
+    '''
+    class Meta:
+        model = Category
+        fields = '__all__' # Inclui todos os campos do modelo Category 
+
+
+class ProductSerializer(serializers.ModelSerializer):
+    '''
+    Serializador para o modelo Product
+    '''
+    class Meta:
+        model = Product
+        fields = '__all__' # Inclui todos os campos do modelo Product
+        

--- a/products/urls.py
+++ b/products/urls.py
@@ -1,0 +1,11 @@
+#products/urls.py 
+
+from rest_framework.routers import DefaultRouter
+from .views import CategoryViewSet, ProductViewSet
+
+router = DefaultRouter()
+router.register(r'categories', CategoryViewSet) # URL base: /api/categories/
+router.register(r'products', ProductViewSet) # URL base: /api/products/
+
+
+urlpatterns = router.urls

--- a/products/views.py
+++ b/products/views.py
@@ -1,3 +1,22 @@
-from django.shortcuts import render
+from rest_framework import viewsets
+from .models import Category, Product 
+from .serializers import CategorySerializer, ProductSerializer
+from rest_framework.permissions import AllowAny, IsAuthenticated
 
-# Create your views here.
+class CategoryViewSet(viewsets.ModelViewSet):
+    '''
+    ViewSet para gerenciar categorias de produtos.
+    Permite operações CRUD (Create, Read, Update, Delete).
+    '''
+    queryset = Category.objects.all()
+    serializer_class = CategorySerializer
+    permission_classes = [AllowAny] # Por enquanto permite acesso a todos os usuários
+
+class ProductViewSet(viewsets.ModelViewSet):
+    '''
+    ViewSet para gerenciar produtos.
+    Permite operações CRUD (Create, Read, Update, Delete).
+    '''
+    queryset = Product.objects.all()
+    serializer_class = ProductSerializer
+    permission_classes = [IsAuthenticated] # Apenas usuários autenticados podem acessar produtos


### PR DESCRIPTION
- Adicionados ViewSets para Categoria e Produto.
- Configurado DRF-Spectacular para documentação OpenAPI/Swagger UI.
- Corrigido problema de permissão 403 para produtos (se aplicável, mencionar se deixou temporariamente AllowAny).
- Resolvido 404 para rota do Swagger UI.