### PR TITLE
feat: Implementar autenticação JWT com simplejwt

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -44,6 +44,9 @@ INSTALLED_APPS = [
     'drf_spectacular',
     'django_filters',
     'drf_yasg',
+    'rest_framework_simplejwt',
+
+
 
     'users',
     'products',
@@ -52,6 +55,7 @@ INSTALLED_APPS = [
 
 REST_FRAMEWORK = { 
     'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework_simplejwt.authentication.JWTAuthentication',
         'rest_framework.authentication.SessionAuthentication',
         'rest_framework.authentication.BasicAuthentication',
     ],

--- a/app/urls.py
+++ b/app/urls.py
@@ -1,8 +1,18 @@
 # app/urls.py
 
 from django.contrib import admin
-from django.urls import path, include # Importe 'include' aqui!
+from django.urls import path, include, re_path # Importe 'include' aqui!
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView, SpectacularRedocView # Inclua Redoc se quiser
+
+# Importação para JWT 
+from rest_framework_simplejwt.views import (
+    TokenObtainPairView,
+    TokenRefreshView,
+    TokenVerifyView,
+)
+
+# Importação para Swagger UI/Spectacular
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView, SpectacularRedocView
 
 urlpatterns = [
     path('admin/', admin.site.urls),
@@ -12,7 +22,11 @@ urlpatterns = [
     path('api/schema/swagger-ui/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
     path('api/schema/redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'), # Opcional: Redoc
 
-    # Inclua as URLs do seu app 'products' aqui
+    #URLs para autenticação JWT
+    path('api/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
+    path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
+    path('api/token/verify/', TokenVerifyView.as_view(), name='token_verify'),
+
     # É crucial que as URLs dos seus apps estejam incluídas!
     path('api/', include('products.urls')), # Isso vai incluir '/api/categories/' e '/api/products/'
 ]

--- a/products/views.py
+++ b/products/views.py
@@ -10,7 +10,7 @@ class CategoryViewSet(viewsets.ModelViewSet):
     '''
     queryset = Category.objects.all()
     serializer_class = CategorySerializer
-    permission_classes = [AllowAny] # Por enquanto permite acesso a todos os usuários
+    permission_classes = [IsAuthenticated] # Por enquanto permite acesso a todos os usuários
 
 class ProductViewSet(viewsets.ModelViewSet):
     '''


### PR DESCRIPTION
- Instalado e configurado `djangorestframework-simplejwt`.
- Adicionadas classes de autenticação padrão em `REST_FRAMEWORK` no `settings.py`.
- Adicionadas rotas JWT para `token`, `refresh` e `verify` em `urls.py`.
- `ProductViewSet` agora exige `IsAuthenticated`.